### PR TITLE
Fizzics: Add 'reset' attribute to globalParameters

### DIFF
--- a/com.endlessm.Fizzics/app/Game.js
+++ b/com.endlessm.Fizzics/app/Game.js
@@ -902,6 +902,7 @@ function Game()
     //--------------------------------------------------------------------------------
     this.update = function( dt, collisionBalls, ballsWithSomeCollision, numBalls, balls )
     {        
+        globalParameters.reset = false;
         gameState.timeInLevel += dt;
 
         if ( gameState.running )

--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -172,7 +172,23 @@ var globalParameters =
     deathVisualBad_4  : 0,
     deathSoundGood_4  : 0,
     deathSoundBad_4   : 0,
-    imageIndex_4      : 0
+    imageIndex_4      : 0,
+
+    //-------------------------------------------------------------------------
+    // HackToolBox uses this variable to know when there was a change to reset
+    // the codeview.
+    //
+    // When you press the reset button in the HackToolBox, it sends a dbus
+    // message to query for the current state of *some* registered attributes
+    // from 'globalParameters'. This is performed by the ClippyWrapper from
+    // HackToolBox. The ClippyWrapper then updates its internal properties, and
+    // the codeview gets notified evertime a property has changed. However,
+    // without this variable that changes its state to true only when the
+    // mentioned dbus message has been set, ClippyWrapper could not detect for
+    // changes. For this reason, we use the 'reset' variable as a dummy variable
+    // that tell us if this dbus method has been invoked.
+    //-------------------------------------------------------------------------
+    reset           : false
 }
 
 
@@ -1647,6 +1663,7 @@ var hackyBalls = new HackyBalls();
 /* globally accessible reset */
 function reset()
 {
+    globalParameters.reset = true;
     hackyBalls.resetGlobalParams();
 }
 


### PR DESCRIPTION
This attribute tells HackToolBox when the Activate dbus method has
been called with the 'reset' string as parameter to reset the
codeview.

https://phabricator.endlessm.com/T24930