### PR TITLE
Fizzics: Hook up sound for NEXT LEVEL button click

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -1069,7 +1069,13 @@ function HackyBalls()
         // send mouse click to the game and get the result
         //--------------------------------------------------
         var gameAction = _game.getMouseDownAction( x, y );
-        if ( gameAction == GAME_ACTION_NEXT_LEVEL  ) { this.setGameLevel( _game.getNextLevel() ); Sounds.play( "fizzics/buttonClick" ); }
+        if ( gameAction == GAME_ACTION_NEXT_LEVEL  ) {
+            if ( !gameState.success )
+                Sounds.play( "fizzics/buttonClick" );
+            else
+                Sounds.play( "fizzics/NEXT-LEVEL/clicked" );
+            this.setGameLevel( _game.getNextLevel() );
+        }
         if ( gameAction == GAME_ACTION_PREV_LEVEL  ) { this.setGameLevel( _game.getPrevLevel() ); Sounds.play( "fizzics/buttonClick" ); }
         if ( gameAction == GAME_ACTION_RESET_LEVEL ) { this.resetLevelOnly(); Sounds.play( "fizzics/buttonClick" ); }
         


### PR DESCRIPTION
Because whether clicking the success dialog or the NEXT LEVEL
button produces the same effect, the "fizzics/NEXT-LEVEL/clicked"
sound is played in both cases.

https://phabricator.endlessm.com/T24885