### PR TITLE
fizzics: Fix "flipped" global parameter

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -201,7 +201,7 @@ var gameState =
 
 function flip()
 {
-    globalParameters.flipped = true;
+    globalParameters.flipped = !globalParameters.flipped;
 }
 
 //----------------------


### PR DESCRIPTION
It seems that this parameter is only set to "true" once, then never set
to "false".