### PR TITLE
soundserver: Support TerminateSound method

### DIFF
--- a/template/app.js
+++ b/template/app.js
@@ -35,4 +35,8 @@ window.Sounds = {
     stop(id) {
         window.webkit.messageHandlers.stopSound.postMessage(id);
     },
+
+    terminate(id) {
+        window.webkit.messageHandlers.terminateSound.postMessage(id);
+    },
 };


### PR DESCRIPTION
https://phabricator.endlessm.com/T25315

This change is **exactly** the same that I wanted to add in the Clubhouse and has been already reviewed by @joaquimrocha 

See the commit 4d61e1e0d6d5a44eef2798ae073104d4fc9a4d09 from https://github.com/endlessm/clubhouse/pull/221

Another approach would be to use the SoundItem idea from the gnome-shell: https://github.com/endlessm/hack-toy-apps/tree/T25315-sound-item but I had no time to test it in the System app. But TBH, this TerminateSound method makes things easier!