### PR TITLE
LightSpeed: add startLevel to globalParameters

### DIFF
--- a/com.endlessm.LightSpeed/app/main.js
+++ b/com.endlessm.LightSpeed/app/main.js
@@ -102,6 +102,24 @@ var game = new Phaser.Game(config);
     }
 }());
 
+/* Quests can start a level programatically */
+game.events.on('global-property-change', (obj, property) => {
+    if (Object.is(globalParameters, obj) && property === 'startLevel' &&
+        globalParameters.currentLevel !== globalParameters.startLevel) {
+        const i = globalParameters.startLevel;
+
+        /* Stop all active scenes just in case */
+        game.scene.getScenes(true).forEach(function(key) {
+            game.scene.stop(key);
+        });
+
+        globalParameters.currentLevel = i;
+        globalParameters.playing = true;
+        globalParameters.paused = false;
+        game.scene.start('level', levelParameters[i]);
+    }
+});
+
 /* External API */
 
 window.flip = function() {

--- a/com.endlessm.LightSpeed/app/parameters.js
+++ b/com.endlessm.LightSpeed/app/parameters.js
@@ -30,8 +30,13 @@ Object.freeze(enemyTypes);
  * Global parameters exposed to the quests and toolbox
  */
 var globalParameters = {
+    /* Number of available levels */
     availableLevels: 1,
+
+    /* Current Level: read only property, 0 for title screen */
     currentLevel: 0,
+
+    /* Next that will be started */
     nextLevel: 1,
 
     /* Level specific parameters */
@@ -42,6 +47,11 @@ var globalParameters = {
 
     /* Communication with Clubhouse */
     flipped: false,
+
+    /* Quests can use this parameter to start any level at any time.
+     * NOTE: Setting this will stop any current level.
+     */
+    startLevel: 0,
 };
 
 /* We need counters and min/max Y coordinate reached for each enemy type,


### PR DESCRIPTION
Add a way to start a level from the outside using clippy.

https://phabricator.endlessm.com/T25688