### PR TITLE
Lightspeed: Fade out ongoing thrust sounds while game paused

### DIFF
--- a/com.endlessm.LightSpeed/app/levelScene.js
+++ b/com.endlessm.LightSpeed/app/levelScene.js
@@ -174,12 +174,20 @@ class LevelScene extends Phaser.Scene {
              * updates working
              */
             if (!this.physics.world.isPaused) {
+                if (this._playingThrustUp)
+                    Sounds.updateSound('lightspeed/thrust-up', 500, {volume: 0});
+                if (this._playingThrustDown)
+                    Sounds.updateSound('lightspeed/thrust-down', 500, {volume: 0});
                 this.scene.launch('pause');
                 this.physics.pause();
             }
             return;
         } else if (this.physics.world.isPaused) {
             Sounds.play('lightspeed/timpani-start-win');
+            if (this._playingThrustUp)
+                Sounds.updateSound('lightspeed/thrust-up', 500, {volume: 1});
+            if (this._playingThrustDown)
+                Sounds.updateSound('lightspeed/thrust-down', 500, {volume: 1});
             this.scene.stop('pause');
             this.physics.resume();
         }


### PR DESCRIPTION
If the game is paused while the thrust sounds are playing, fade their
volume to zero until the game is unpaused. Otherwise, the thrust sound
effect keeps looping during the pause scene.

https://phabricator.endlessm.com/T25699