### PR TITLE
Lightspeed: Fix capitalization of app name

### DIFF
--- a/com.endlessm.LightSpeed/data/app.desktop
+++ b/com.endlessm.LightSpeed/data/app.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=LightSpeed
+Name=Lightspeed
 Type=Application
 Exec=com.endlessm.LightSpeed
 StartupNotify=true

--- a/com.endlessm.LightSpeed/data/appdata.xml
+++ b/com.endlessm.LightSpeed/data/appdata.xml
@@ -6,7 +6,7 @@
   <categories>
     <category>Game</category>
   </categories>
-  <name>LightSpeed</name>
+  <name>Lightspeed</name>
   <summary>Learn to design your own game</summary>
 
   <description><p></p></description>


### PR DESCRIPTION
The correct name is "Lightspeed" with a lowercase S. Nonetheless, we
should not change the app ID at this point, only the user-visible name.

https://phabricator.endlessm.com/T25782