### PR TITLE
Lightspeed: Start level chooser at last available level

### DIFF
--- a/com.endlessm.LightSpeed/app/startScene.js
+++ b/com.endlessm.LightSpeed/app/startScene.js
@@ -25,7 +25,8 @@ class StartScene extends Phaser.Scene {
     create() {
         /* Reset Global game state */
         globalParameters.playing = false;
-        globalParameters.currentLevel = globalParameters.nextLevel || 1;
+        globalParameters.currentLevel =
+            globalParameters.nextLevel || globalParameters.availableLevels;
 
         const levelParams = levelParameters[globalParameters.currentLevel];
         const spacing = 16;


### PR DESCRIPTION
Previously, it would start at level 1 if the quest had not specified a
specific level. Now it starts at the last available level. (A level
specified by the quest still overrides this.)

https://phabricator.endlessm.com/T25754