### PR TITLE
data: Add the desktop suffix to the AppData

### DIFF
--- a/com.endlessm.HackUnlock/data/appdata.xml
+++ b/com.endlessm.HackUnlock/data/appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.endlessm.HackUnlock</id>
+  <id>com.endlessm.HackUnlock.desktop</id>
   <metadata_license>CC0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
 </component>


### PR DESCRIPTION
Without the desktop suffix, GNOME Software's plugins will not match the
right application, and thus the logic of including the right app object
as part of the Hack proxy app in g-s will not work.

https://phabricator.endlessm.com/T25856