### PR TITLE
LightSpeed: Pre-load button in the GameOverScene

### DIFF
--- a/com.endlessm.LightSpeed/app/gameOverScene.js
+++ b/com.endlessm.LightSpeed/app/gameOverScene.js
@@ -15,6 +15,8 @@ class GameOverScene extends Phaser.Scene {
     preload() {
         this.load.image('game-over', 'assets/game-over.png');
         this.load.image('game-over-glow', 'assets/game-over-glow.png');
+
+        Utils.load_button(this, 'button');
     }
 
     create() {


### PR DESCRIPTION
The restart button's asset in the Game Over scene was not being drawn
when running a level from a quest (during normal game play it was
fine).
The reason is that the button was only being pre-loaded in the Start
screne, which is not loaded if the app is opened and the quest sets
its desired level directly. To fix that, this patch adds a pre-load
of the button to the Game Over scene as well, this way it will always
be loaded when needed.

https://phabricator.endlessm.com/T25860