### PR TITLE
Save state for every level

### DIFF
--- a/com.endlessm.LightSpeed/app/levelScene.js
+++ b/com.endlessm.LightSpeed/app/levelScene.js
@@ -6,8 +6,8 @@
  */
 
 /* exported LevelScene */
-/* global ToyApp, enemyTypes, shipTypes, SpawnAstronautScope, SpawnEnemyScope,
-   UpdateEnemyScope */
+/* global enemyTypes, saveState, shipTypes, SpawnAstronautScope,
+SpawnEnemyScope, UpdateEnemyScope */
 
 function getUserFunction(code) {
     if (!code)
@@ -233,7 +233,7 @@ class LevelScene extends Phaser.Scene {
 
     onFlip() {
         this.resetQuestData();
-        this._saveState();
+        saveState();
     }
 
     /* Private functions */
@@ -247,23 +247,6 @@ class LevelScene extends Phaser.Scene {
             globalParameters[`enemyType${i}MaxY`] = -1e9;
             this.firstObjectOfType[i] = null;
         }
-    }
-
-    _saveState() {
-        ToyApp.saveState({
-            /* Global state */
-            availableLevels: globalParameters.availableLevels,
-            nextLevel: globalParameters.nextLevel,
-            /* Level state */
-            level: globalParameters.currentLevel,
-            /* Global user functions */
-            updateAsteroidCode: globalParameters.updateAsteroidCode,
-            updateSpinnerCode: globalParameters.updateSpinnerCode,
-            updateSquidCode: globalParameters.updateSquidCode,
-            updateBeamCode: globalParameters.updateBeamCode,
-            /* Per-level parameters */
-            parameters: this.params,
-        });
     }
 
     playThrust(direction) {
@@ -497,7 +480,7 @@ class LevelScene extends Phaser.Scene {
                 globalParameters.nextLevel = 0;
 
             /* Save game state when level is finished */
-            this._saveState();
+            saveState();
 
             this.scene.launch('continue',
                 `Level ${globalParameters.currentLevel} Complete!`);

--- a/com.endlessm.LightSpeed/app/main.js
+++ b/com.endlessm.LightSpeed/app/main.js
@@ -9,7 +9,7 @@
 
 /* global globalParameters, defaultLevelParameters, defaultParameters,
     levelParameters, ContinueScene, DebugScene, GameOverScene, LevelScene,
-    StartScene, TitleScene */
+    StartScene, TitleScene, ToyApp */
 
 const fontConfig = {
     color: 'white',
@@ -143,13 +143,31 @@ window.reset = function() {
     Object.assign(levelParameters[i], defaultLevelParameters[i]);
 };
 
+window.saveState = function() {
+    ToyApp.saveState({
+        /* Global state */
+        availableLevels: globalParameters.availableLevels,
+        nextLevel: globalParameters.nextLevel,
+        /* Level state */
+        level: globalParameters.currentLevel,
+        /* Global user functions */
+        updateAsteroidCode: globalParameters.updateAsteroidCode,
+        updateSpinnerCode: globalParameters.updateSpinnerCode,
+        updateSquidCode: globalParameters.updateSquidCode,
+        updateBeamCode: globalParameters.updateBeamCode,
+        /* Per-level parameters */
+        levelParameters,
+    });
+};
+
 window.loadState = function(state) {
     /* Do some sanity checks before restoring game state */
     if (typeof state === 'object' &&
         typeof state.availableLevels === 'number' &&
         typeof state.nextLevel === 'number' &&
         typeof state.level === 'number' &&
-        typeof state.parameters === 'object' &&
+        Array.isArray(state.levelParameters) &&
+        state.levelParameters.every(obj => typeof obj === 'object') &&
         state.nextLevel < state.availableLevels &&
         state.level >= 0 && state.level <= state.availableLevels) {
         /* Restore global parameters */
@@ -161,7 +179,9 @@ window.loadState = function(state) {
         globalParameters.updateBeamCode = state.updateBeamCode;
 
         /* Restore current level parameters */
-        Object.assign(levelParameters[state.level], state.parameters);
+        state.levelParameters.forEach((levelState, ix) => {
+            Object.assign(levelParameters[ix], levelState);
+        });
     }
 };
 


### PR DESCRIPTION
Includes a rebase of Noel's earlier commit to save the state on flip, not only on level success.

This pull request is stacked on top of #193, so review that one first.

https://phabricator.endlessm.com/T25561