### PR TITLE
LightSpeed: use default spawn scope for powerups

### DIFF
--- a/com.endlessm.LightSpeed/app/parameters.js
+++ b/com.endlessm.LightSpeed/app/parameters.js
@@ -228,7 +228,7 @@ var defaultLevelParameters = [
 
         spawnPowerupCode: `\
     ${TICK_COMMENT}
-    if (tickCount > 50)
+    if (ticksSinceSpawn > random(60, 240))
         return null;`,
     },
 
@@ -242,7 +242,7 @@ var defaultLevelParameters = [
 
         spawnPowerupCode: `\
     ${TICK_COMMENT}
-    if (tickCount > 50)
+    if (ticksSinceSpawn > random(60, 240))
         return null;`,
     },
 
@@ -256,7 +256,7 @@ var defaultLevelParameters = [
 
         spawnPowerupCode: `\
     ${TICK_COMMENT}
-    if (tickCount > 50)
+    if (ticksSinceSpawn > random(60, 240))
         return 'upgrade';
 
     return null;`,
@@ -266,7 +266,7 @@ var defaultLevelParameters = [
     {
         spawnPowerupCode: `\
     ${TICK_COMMENT}
-    if (tickCount > 50) {
+    if (ticksSinceSpawn > random(60, 240)) {
         return pickOne('blowup', 'invincibility', 'upgrade');
     }`,
 

--- a/com.endlessm.LightSpeed/app/userScope.js
+++ b/com.endlessm.LightSpeed/app/userScope.js
@@ -88,30 +88,7 @@ class SpawnAstronautScope extends SpawnScope {
 class SpawnEnemyScope extends SpawnScope {
 }
 
-class SpawnPowerupScope extends UserScope {
-    constructor() {
-        super();
-        this.tickDelay = 0;
-        this.tickCount = 0;
-    }
-
-    update(data) {
-        super.update(data);
-
-        /* Return false to stop function execution */
-        if (--this.tickDelay > 0)
-            return false;
-
-        this.tickCount++;
-        this.tickDelay = this.random(100, 300);
-
-        return true;
-    }
-
-    postUpdate(retval) {
-        if (retval)
-            this.tickCount = 0;
-    }
+class SpawnPowerupScope extends SpawnScope {
 }
 
 /*


### PR DESCRIPTION
Use the same spawn scope for spawnPowerup() function.
Instead of increasing tickCount at random intervals users can
compare ticksSinceSpawn with a random value.

https://phabricator.endlessm.com/T26188