### PR TITLE
LightSpeed: use loose equality operator in user functions

### DIFF
--- a/com.endlessm.LightSpeed/app/parameters.js
+++ b/com.endlessm.LightSpeed/app/parameters.js
@@ -85,7 +85,7 @@ function resetGlobalUserCode() {
     }`;
 
     globalParameters.activatePowerupCode = `\
-    if (powerUpType === 'invulnerable') {
+    if (powerUpType == 'invulnerable') {
 
     }`;
 }


### PR DESCRIPTION
Do not use strict equality operator in activatePowerup() default.

https://phabricator.endlessm.com/T26316