### PR TITLE
Lightspeed: Add constants to scope

### DIFF
--- a/com.endlessm.LightSpeed/app/parameters.js
+++ b/com.endlessm.LightSpeed/app/parameters.js
@@ -85,7 +85,7 @@ function resetGlobalUserCode() {
     }`;
 
     globalParameters.activatePowerupCode = `\
-    if (powerUpType === 'invulnerable') {
+    if (powerUpType === invulnerable) {
 
     }`;
 }
@@ -177,7 +177,7 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 70) {
-        return 'asteroid';
+        return asteroid;
     }`,
     },
 
@@ -187,7 +187,7 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
     },
 
@@ -197,7 +197,7 @@ var defaultLevelParameters = [
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
         return {
-            type: 'asteroid',
+            type: asteroid,
             scale: 150
         };
     }`,
@@ -217,7 +217,7 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
     },
 
@@ -246,7 +246,7 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
 
         spawnPowerupCode: `\
@@ -260,13 +260,13 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
 
         spawnPowerupCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > random(60, 240))
-        return 'invulnerable';`,
+        return invulnerable;`,
     },
 
     /* Level 13 */
@@ -274,13 +274,13 @@ var defaultLevelParameters = [
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
 
         spawnPowerupCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > random(60, 240))
-        return 'upgrade';
+        return upgrade;
 
     return null;`,
     },
@@ -290,13 +290,13 @@ var defaultLevelParameters = [
         spawnPowerupCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > random(60, 240)) {
-        return pickOne('invulnerable', 'blowup', 'upgrade');
+        return pickOne(invulnerable, blowup, upgrade);
     }`,
 
         spawnEnemyCode: `\
     ${TICK_COMMENT}
     if (ticksSinceSpawn > 40) {
-        return 'asteroid';
+        return asteroid;
     }`,
     },
 ];

--- a/com.endlessm.LightSpeed/app/userScope.js
+++ b/com.endlessm.LightSpeed/app/userScope.js
@@ -24,6 +24,12 @@ class UserScope {
         this.shipTypes = shipTypes;
         this.enemyTypes = enemyTypes;
         this.data = {};
+
+        [this.shipTypes, this.enemyTypes].forEach(names => {
+            names.forEach(name => {
+                this[name] = name;
+            });
+        });
     }
 
     update(data) {
@@ -89,6 +95,13 @@ class SpawnEnemyScope extends SpawnScope {
 }
 
 class SpawnPowerupScope extends SpawnScope {
+    constructor() {
+        super();
+        const constants = ['blowup', 'invulnerable', 'upgrade'];
+        constants.forEach(name => {
+            this[name] = name;
+        });
+    }
 }
 
 /*
@@ -130,6 +143,12 @@ class ActivatePowerupScope extends UserScope {
 
         this._blowUpEnemies = false;
         this.powerUpType = null;
+
+        const constants = ['blowup', 'invulnerable', 'upgrade', 'shrink',
+            'attraction', 'engine'];
+        constants.forEach(name => {
+            this[name] = name;
+        });
     }
 
     update(data) {


### PR DESCRIPTION
Typing quotes around values like 'invulnerable' has proven to cause
problems for players, since we don't actually teach them what strings
are.

Add constants to the scope objects where applicable, giving each one the
value of the string that would previously have been required, so that we
can keep backwards compatibility.

This allows typing

    return invulnerable;

from spawnPowerup(), rather than

    return 'invulnerable';

We change the default level functions accordingly.

https://phabricator.endlessm.com/T26373