### PR TITLE
Sidetrack - re-ordering instructions does not preserve the error text

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -62,6 +62,8 @@ class GameScene extends Phaser.Scene {
         this.arrSpriteMoves = [];
         this.moves = [];
 
+        this.badPropertyNames = [];
+
         // capture tiles player was on
         this.arrTileHistory = [];
 
@@ -721,8 +723,8 @@ class GameScene extends Phaser.Scene {
                 if (this.arrSpriteMoves[i].moveType === PUSH)
                     instructions.push('riley.push();');
 
-                if (this.arrSpriteMoves[i].moveType === ERROR)
-                    instructions.push('riley.error();');
+                if (this.arrSpriteMoves[i].frame.name === ERROR)
+                    instructions.push(`riley.${this.arrSpriteMoves[i].badPropertyName}();`);
             }
 
             this.params.instructionCode = instructions.join('\n ');
@@ -756,6 +758,9 @@ class GameScene extends Phaser.Scene {
                 moveSquare.setInteractive({useHandCursor: true});
                 this.input.setDraggable(moveSquare);
                 moveSquare.dragDistanceThreshold = 16;
+
+                if (this.moves[i] === ERROR)
+                    moveSquare.badPropertyName = this.badPropertyNames.shift() || 'error';
             }
         }
     }
@@ -1251,6 +1256,7 @@ class GameScene extends Phaser.Scene {
         try {
             this.instructionCode(scope);
             this.moves = scope.riley.moves;
+            this.badPropertyNames = scope.riley._badPropertyNames;
         } catch (e) {
             /* User function error! */
             console.error(e);  // eslint-disable-line no-console

--- a/com.endlessm.Sidetrack/app/js/userScope.js
+++ b/com.endlessm.Sidetrack/app/js/userScope.js
@@ -38,6 +38,7 @@ class Obstacle {
 class riley {
     constructor() {
         this.moves = [];
+        this._badPropertyNames = [];
     }
 
     forward() {
@@ -69,6 +70,8 @@ const handler = {
     get(target, name, receiver) {
         if (name in target)
             return Reflect.get(target, name, receiver);
+
+        target._badPropertyNames.push(name);
         return target.error;
     },
 };


### PR DESCRIPTION
https://phabricator.endlessm.com/T26470

How should we handle move instructions if it's gibberish?
All the move instructions need to have riley class first. i.e. riley.forward(), 
But typing just gibberish will error out, and no instructions appear. How should this be handled?