### PR TITLE
Sidetrack: Restart level when editing code for level or instructions

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -1393,9 +1393,11 @@ class GameScene extends Phaser.Scene {
         if (property === 'instructionCode') {
             this.instructionCode = getUserFunction(this.params.instructionCode);
             this.runInstruction();
+            this.scene.restart(levelParameters[globalParameters.currentLevel]);
         } else if (property === 'levelCode') {
             this.levelCode = getUserFunction(this.params.levelCode);
             this.runObstacles();
+            this.scene.restart(levelParameters[globalParameters.currentLevel]);
         } else if (property === 'robotADirection') {
             this.robotADirection = this.getRobotDirection(this.params.robotADirection, ROBOTA);
             this.setRobotsFrame();


### PR DESCRIPTION
Otherwise, the new obstacles or new instructions don't show up until you
restart the level or die.

It's debatable whether restarting the level is the right thing to do
here, but I think in practice it doesn't make much of a difference. Once
you are in automatic mode you can't be paused in the middle of the
level, so you are either not-yet-started, dead, or victorious. I expect
the instructions and level code will mostly only be edited in the
not-yet-started or dead states.

https://phabricator.endlessm.com/T26471