### PR TITLE
Sidetrack: Specify toolbox window shader

### DIFF
--- a/com.endlessm.Sidetrack/data/app.desktop
+++ b/com.endlessm.Sidetrack/data/app.desktop
@@ -8,4 +8,4 @@ Icon=com.endlessm.Sidetrack
 Categories=Game;
 X-Endless-LaunchMaximized=true
 X-Endless-SplashBackground=com.endlessm.Sidetrack.jpg
-X-Endless-HackShader=Sidetrack
+X-Endless-HackShader=desaturate


### PR DESCRIPTION
The are two shaders currently available for this property, "fizzics" and
"desaturate". We specify the latter, since a nonexistent value means no
shader is applied at all.

https://phabricator.endlessm.com/T26601