### PR TITLE
Fizzics: Don't allow creating species if it is disabled

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -456,10 +456,9 @@ function HackyBalls()
 
 
     //------------------------------------------
-    this.createBall = function( x, y, species )
-    {    
-        if ( _numBalls < MAX_BALLS )
-        {
+    this.createBall = function(x, y, species) {
+        if (_numBalls < MAX_BALLS &&
+            !globalParameters[`createType${species}Disabled`]) {
             if (!_levelLoading)
             {
                 Sounds.play( _species[ species ].createSound );


### PR DESCRIPTION
Ideally we would listen to changes on this parameter and select the
first species that it is allowed to create, but a notification mechanism
doesn't exist in Fizzics.

Therefore we check the global parameters when adding a ball, and play
the "BZZT!" sound if that ball's species is not allowed to be added.

https://phabricator.endlessm.com/T26391