### PR TITLE
Sidetrack - felixnet escape quest integration and workflow

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -1338,7 +1338,8 @@ class GameScene extends Phaser.Scene {
                 duration: 2000,
                 x: this.sys.game.config.width,
                 onComplete: () => {
-                    globalParameters.success = true;
+                    // set to false so quest knows to fire felix cutscene
+                    globalParameters.willPlayFelixEscapeAnimation = false;
                 },
             });
         } else {


### PR DESCRIPTION
Setting globalParameters.success = true didn't work because value is already set to true by default.
Instead, change willPlayFelixEscapeAnimation to false will alert quest to play felix escape cutscene.