### PR TITLE
Sidetrack: highestAchievedLevel is off by one

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -100,6 +100,7 @@ class GameScene extends Phaser.Scene {
         this.isAnimating = false;
 
         this.playerYOffset = -24;
+        this.nextLevel = globalParameters.highestAchievedLevel;
 
         // few sanity checks to make sure data is coming through
         if (this.params) {
@@ -119,9 +120,6 @@ class GameScene extends Phaser.Scene {
         }
 
         this.cameras.main.setBackgroundColor('#131430');
-
-        if (globalParameters.currentLevel > globalParameters.highestAchievedLevel)
-            globalParameters.highestAchievedLevel = globalParameters.currentLevel;
     }
 
     create() {
@@ -1203,15 +1201,8 @@ class GameScene extends Phaser.Scene {
 
     continueLevel() {
         Sounds.play('sidetrack/sfx/start_chime');
-        let nextLevel;
-
-        if (globalParameters.currentLevel < globalParameters.availableLevels)
-            nextLevel = globalParameters.currentLevel + 1;
-        else
-            nextLevel = globalParameters.highestAchievedLevel;
-
         globalParameters.playing = true;
-        this.scene.restart(levelParameters[nextLevel]);
+        this.scene.restart(levelParameters[this.nextLevel]);
     }
 
     restartLevel() {
@@ -1321,6 +1312,14 @@ class GameScene extends Phaser.Scene {
         Sounds.play('sidetrack/sfx/success');
 
         this.player.setFrame(this.RILEYWINFRAME);
+
+        if (globalParameters.currentLevel < globalParameters.availableLevels)
+            this.nextLevel = globalParameters.currentLevel + 1;
+        else
+            this.nextLevel = globalParameters.highestAchievedLevel;
+
+        if (this.nextLevel > globalParameters.highestAchievedLevel)
+            globalParameters.highestAchievedLevel = this.nextLevel;
 
         saveState();
 


### PR DESCRIPTION
Moved setting globalParameters.highestAchievedLevel from game level start to when level is completed and then saving the state.
https://phabricator.endlessm.com/T26624