### PR TITLE
Sidetrack - Play button stops working

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -125,6 +125,8 @@ class GameScene extends Phaser.Scene {
                 this.getRobotDirection(this.params.robotBDirection, ROBOTB);
         }
 
+        globalParameters.playing = true;
+
         this.cameras.main.setBackgroundColor('#131430');
     }
 
@@ -1257,7 +1259,6 @@ class GameScene extends Phaser.Scene {
 
     continueLevel() {
         Sounds.play('sidetrack/sfx/start_chime');
-        globalParameters.playing = true;
         this.scene.restart(levelParameters[this.nextLevel]);
     }
 
@@ -1265,7 +1266,6 @@ class GameScene extends Phaser.Scene {
         if (this.isAnimating)
             return;
         Sounds.play('sidetrack/sfx/start_chime');
-        globalParameters.playing = true;
         globalParameters.currentLevel = this.params.level;
         this.scene.restart(levelParameters[globalParameters.currentLevel]);
     }


### PR DESCRIPTION
When game is over we set globalParameters.playing to false. When we click restart, or continue we change this value to true. However, when modifying the instructions code, we restart the level without changing this value back to true. This causes the update method to return and do nothing, which pretty much stops from being able to play the game.

Changed it so that on anytime a level starts, globalParameters.playing is set to true. 