### PR TITLE
LightSpeed: Convert enemy max/min Y to user space

### DIFF
--- a/com.endlessm.LightSpeed/app/levelScene.js
+++ b/com.endlessm.LightSpeed/app/levelScene.js
@@ -719,7 +719,7 @@ class LevelScene extends Phaser.Scene {
 
                 if (obj.isFirstOne) {
                     const index = obj.enemyTypeIndex;
-                    const y = obj.y;
+                    const {y} = this.userSpace.transformPoint(obj.x, obj.y);
 
                     /* Update enemy type min/max globals */
                     globalParameters[`enemyType${index}MinY`] =


### PR DESCRIPTION
This is the format expected by the quests. The quests regressed
because of this change.

https://phabricator.endlessm.com/T26639