### PR TITLE
Instructions code generated when reordering instructions in Sidetrack should be indented correctly

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -858,8 +858,13 @@ class GameScene extends Phaser.Scene {
                     instructions.push(`riley.${this.arrSpriteMoves[i].badPropertyName}();`);
             }
 
+            // this is kind of a hack to add proper indentation in toolbox
+            const indent = '    ';
+            for (var j = 0; j < instructions.length; j++)
+                instructions[j] = indent + instructions[j];
+
             this.isInGameInstructionUpdate = true;
-            this.params.instructionCode = instructions.join('\n ');
+            this.params.instructionCode = instructions.join('\n');
         });
     }
 


### PR DESCRIPTION
Added a hack on the toy app side to add proper indentation when flipping to toolbox. 
Instead of doing this on toyapp side, maybe trim and add proper indentation on toolbox side?
https://phabricator.endlessm.com/T26691