### PR TITLE
Fizzics: Fix top board positioning

### DIFF
--- a/com.endlessm.Fizzics/app/Game.js
+++ b/com.endlessm.Fizzics/app/Game.js
@@ -202,7 +202,7 @@ function Game()
     
     
     //----------------------------------------
-    this.initializeUserInterface = function()
+    this.initializeUserInterface = function(defaultWidth)
     {                
         //-------------------------------------------
         // set up UI layout
@@ -227,12 +227,12 @@ function Game()
 
         _successScreen.width   =  908 * UI_SCALE;
         _successScreen.height  = 1494 * UI_SCALE;
-        
+
         var buttonHeight = _levelboard.y + _levelboard.height * 0.1;
 
-        var left = canvasID.width * ONE_HALF - ( _levelboard.width + _scoreboard.width + _flingboard.width ) * ONE_HALF;
+        var left = defaultWidth * ONE_HALF - ( _levelboard.width + _scoreboard.width + _flingboard.width ) * ONE_HALF;
         var top = 0;
-        
+
         _levelboard.x = left;
         _scoreboard.x = _levelboard.x + _levelboard.width;
         _flingboard.x = _scoreboard.x + _scoreboard.width;


### PR DESCRIPTION
In a previous commit (9f9112e) it was supposed to pass the default width
to the UI initialization function, but due to a mistake, the part where
the function used that value was not added to the commit.

This patch adds that missing part, thus fixing the positioning of the
top board when the window is resized while being initialized (click on
the Fizzics icon and when the splash screen is shown hit the Super key
to show the overview).

https://phabricator.endlessm.com/T26164