### PR TITLE
LightSpeed: reset score before recreating level scene.

### DIFF
--- a/com.endlessm.LightSpeed/app/levelScene.js
+++ b/com.endlessm.LightSpeed/app/levelScene.js
@@ -109,6 +109,10 @@ class LevelScene extends Phaser.Scene {
     }
 
     create() {
+        /* Reset Global game state */
+        globalParameters.success = false;
+        globalParameters.score = 0;
+
         const centerY = game.config.height / 2;
 
         /* Fade in scene */
@@ -167,10 +171,6 @@ class LevelScene extends Phaser.Scene {
             this.game.events.off('global-property-change',
                 this.onGlobalPropertyChange, this);
         }, this);
-
-        /* Reset Global game state */
-        globalParameters.success = false;
-        globalParameters.score = 0;
 
         this.updatePlayingState();
     }


### PR DESCRIPTION
Reset global score before checking if the level is done to avoid skipping levels.

https://phabricator.endlessm.com/T26754