### PR TITLE
Sidetrack: Don't fill queue with NONE in manual levels

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -1467,6 +1467,11 @@ class GameScene extends Phaser.Scene {
         if (!this.instructionCode)
             return;
 
+        if (this.gameType === DEFAULTGAME) {
+            this.queue = [];
+            return;
+        }
+
         var scope = this.userInstructionsCodeScope;
 
         try {


### PR DESCRIPTION
In the manual levels, runInstruction() would fill the instruction queue
with NONE instructions because the instructions code is blank. Then
pressing the arrow or spacebar keys would attempt to append instructions
to the queue, starting them at position 8 instead of position 1, so only
the NONE instruction would get executed.

Instead, on manual control levels, we empty the queue and return early
from runInstruction().

https://phabricator.endlessm.com/T26751