### PR TITLE
Sidetrack ep4 - Dragging instruction to the right is off by 1

### DIFF
--- a/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.endlessm.Sidetrack/app/js/scenes/gameScene.js
@@ -820,8 +820,8 @@ class GameScene extends Phaser.Scene {
             const index = this.arrSpriteMoves.indexOf(gameObject);
 
             if (this.separator.visible) {
-                this.arrSpriteMoves =
-                    this.arrayMove(this.arrSpriteMoves, index, this.separator.position);
+                this.arrSpriteMoves = this.reorderInstructions(this.arrSpriteMoves,
+                    index, this.separator.position);
                 this.separator.setVisible(false);
             }
 
@@ -1126,13 +1126,16 @@ class GameScene extends Phaser.Scene {
         }
     }
 
-    arrayMove(arr, old_index, new_index) {
+    reorderInstructions(arr, old_index, new_index) {
         void this;
+        let index = new_index;
+        if (old_index < new_index)
+            index--;
 
         if (new_index >= arr.length)
             arr.push(arr.splice(old_index, 1)[0]);
         else
-            arr.splice(new_index, 0, arr.splice(old_index, 1)[0]);
+            arr.splice(index, 0, arr.splice(old_index, 1)[0]);
 
         return arr;
     }


### PR DESCRIPTION
In auto mode- drag the very first instruction. Then drop it between 1 and 2.

Drag an instruction and drop it one spot over to the right. The instruction that is dropped should be in the 1 slot, but is instead dropped on the 2 spot. 

https://phabricator.endlessm.com/T26781