### PR TITLE
Fizzics: Only check if adding balls is disabled when it's user started

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -457,8 +457,7 @@ function HackyBalls()
 
     //------------------------------------------
     this.createBall = function(x, y, species) {
-        if (_numBalls < MAX_BALLS &&
-            !globalParameters[`createType${species}Disabled`]) {
+        if (_numBalls < MAX_BALLS) {
             if (!globalParameters.levelLoading)
             {
                 Sounds.play( _species[ species ].createSound );
@@ -1447,8 +1446,9 @@ function HackyBalls()
     
     //---------------------------------
     this.spaceKeyPressed = function()
-    {    
-        this.createBall( _mousePosition.x, _mousePosition.y, _selectedSpecies );        
+    {
+        if (!globalParameters[`createType${species}Disabled`])
+            this.createBall( _mousePosition.x, _mousePosition.y, _selectedSpecies );
     }
 
     //---------------------------------


### PR DESCRIPTION
The createBall function was checking whether the ball species creation
had been disabled, and this meant that when resetting the level after
one or more balls had been disabled (as in the Episode4 FizzicsKey
quest) the ball repositioning didn't work.

This patch fixes that by moving the "disabled-ball-creation" check into
the functions that are triggered by the user's actions.

https://phabricator.endlessm.com/T26698