### PR TITLE
Fizzics: Discard user-added balls on reset

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -1075,6 +1075,8 @@ function HackyBalls()
         _numBalls = 0;
         globalParameters.levelLoading = true;
         _game.setLevel( this, _game.getCurrentLevel(), _collisionBalls, _ballsWithSomeCollision ); 
+        _tools.select(-1);
+
         globalParameters.levelLoading = false;
     }
 


### PR DESCRIPTION
When resetting a level, if the user had added any balls, then they'd be
repositioned to the top of the screen. It's unclear whether a reset
should keep the added balls in their original position or discard them,
but certainly they shouldn't be all set at the same position at the top.

So this patch discards any user-added balls to the level. It does so by
selecting no tool (!), which is surprising but not worth investigating
why it works like that because we'll be porting/rewriting the game
appropriately anyway...

https://phabricator.endlessm.com/T26698