### PR TITLE
Fizzics: consume click events on game actions

### DIFF
--- a/com.endlessm.Fizzics/app/HackyBalls.js
+++ b/com.endlessm.Fizzics/app/HackyBalls.js
@@ -1101,10 +1101,19 @@ function HackyBalls()
             else
                 Sounds.play( "fizzics/NEXT-LEVEL/clicked" );
             this.setGameLevel( _game.getNextLevel() );
+            return;
         }
-        if ( gameAction == GAME_ACTION_PREV_LEVEL  ) { this.setGameLevel( _game.getPrevLevel() ); Sounds.play( "fizzics/buttonClick" ); }
-        if ( gameAction == GAME_ACTION_RESET_LEVEL ) { this.resetLevelOnly(); Sounds.play( "fizzics/buttonClick" ); }
-        
+        if ( gameAction == GAME_ACTION_PREV_LEVEL  ) {
+            this.setGameLevel( _game.getPrevLevel() );
+            Sounds.play( "fizzics/buttonClick" );
+            return;
+        }
+        if ( gameAction == GAME_ACTION_RESET_LEVEL ) {
+            this.resetLevelOnly();
+            Sounds.play( "fizzics/buttonClick" );
+            return;
+        }
+
         //--------------------------
         // detect selecting a tool
         //--------------------------


### PR DESCRIPTION
Clicking on a button like reset was not consuming the event
Adding a ball behind the button if the add tool was selected.

https://phabricator.endlessm.com/T26814