### PR TITLE
Runner app: Reduce topbar margin

### DIFF
--- a/template/topbar.ui
+++ b/template/topbar.ui
@@ -21,10 +21,10 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">12</property>
-                <property name="margin_right">12</property>
-                <property name="margin_top">12</property>
-                <property name="margin_bottom">12</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkButtonBox">


### PR DESCRIPTION
Topbar height should match the height of the header bar of other
apps.

https://phabricator.endlessm.com/T27188