### PR TITLE
Unlock: Minimize, fade out and show topbar always

### DIFF
--- a/com.endlessm.HackUnlock/app/Unlock.js
+++ b/com.endlessm.HackUnlock/app/Unlock.js
@@ -253,10 +253,9 @@ function Unlock()
             globalParameters.unlocked = true;
             globalParameters.mode = MODE_VIDEO_PLAYED;
 
-            if (window.ToyApp.isHackMode)
-                window.ToyApp.hideToolbox();
+            window.ToyApp.hideToolbox();
 
-            const fadeDurationMs = window.ToyApp.isHackMode ? 2000 : 0;
+            const fadeDurationMs = 2000;
             window.ToyApp.quit(fadeDurationMs);
         });
         _video.play();

--- a/template/app.py
+++ b/template/app.py
@@ -75,8 +75,7 @@ class ToyAppWindow(Gtk.ApplicationWindow):
         app_info = Gio.DesktopAppInfo.new(self.app_id + '.desktop')
         decorated = metadata.get('decorated', True)
         hack_mode_properties = metadata.get('hack-mode-properties', {})
-        self.show_topbar = (self.app.is_hack_mode and
-                            hack_mode_properties.get('topbar', False))
+        self.show_topbar = hack_mode_properties.get('topbar', False)
         use_load_notify = metadata.get('use-load-notify', False)
 
         self._played_async_sounds = {}
@@ -85,7 +84,7 @@ class ToyAppWindow(Gtk.ApplicationWindow):
         self.set_application(application)
         self.set_title(app_info.get_name())
         self.set_decorated(decorated)
-        if self.app.is_hack_mode and self.app_id == "com.endlessm.HackUnlock":
+        if self.app_id == "com.endlessm.HackUnlock":
             Desktop.minimize_all()
         self.maximize()
 


### PR DESCRIPTION
Do not depend on hack-mode-enabled to minimize all the windows
before starting Unlock, to fade out and to show the topbar with
the close button

https://phabricator.endlessm.com/T27376