### PR TITLE
OperatingSystemApp: mark app as a rename

### DIFF
--- a/com.hack_computer.OperatingSystemApp/data/app.desktop
+++ b/com.hack_computer.OperatingSystemApp/data/app.desktop
@@ -8,3 +8,4 @@ Icon=com.hack_computer.OperatingSystemApp
 Categories=Game;
 X-Endless-LaunchMaximized=true
 X-Endless-SplashBackground=com.hack_computer.OperatingSystemApp.jpg
+X-Flatpak-RenamedFrom=com.endlessm.OperatingSystemApp.desktop


### PR DESCRIPTION
The Shell can detect if an app has been renamed. If a desktop file referenced in the icon-grid-layout is not available anymore it will check in other desktop files available for a X-Flatpak-RenamedFrom key and replaces the corresponding app accordingly.

https://github.com/endlessm/gnome-shell/blob/a554aadb53d1ad9ffe844920abd3f5302c25eb3a/src/shell-app-system.c#L158-L175

https://phabricator.endlessm.com/T28554