### PR TITLE
Sidetrack: Add need hack screen

### DIFF
--- a/com.hack_computer.Sidetrack/app/index.html
+++ b/com.hack_computer.Sidetrack/app/index.html
@@ -21,6 +21,7 @@
             background-image: url("assets/images/pauseScreen.jpg");
         }
     </style>
+    <link type="text/css" rel="stylesheet" href="common.css">
 </head>
 <body class="bg">
     <script src="js/parameters.js"></script>

--- a/com.hack_computer.Sidetrack/app/js/main.js
+++ b/com.hack_computer.Sidetrack/app/js/main.js
@@ -171,3 +171,7 @@ window.loadState = function(state) {
 
     loadingScene.doneLoadingState();
 };
+
+window.runningQuestChanged = function() {
+    game.scene.getScene('Game').restartLevel();
+}

--- a/com.hack_computer.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.hack_computer.Sidetrack/app/js/scenes/gameScene.js
@@ -1077,6 +1077,20 @@ class GameScene extends Phaser.Scene {
         // create the starting tile
         const startingTile = this.add.sprite(0, 0, 'specialTiles', 0).setOrigin(0);
         this.setSpritePosition(startingTile, this.playerXLocation, this.playerYLocation, -352);
+
+        // Show need hack modal after level 14 to ensure that following levels
+        // are played only with quests
+        if (ToyApp.isHackMode && ToyApp.runningQuest) {
+            hideNeedHackScreen();
+        } else {
+            if (this.levelNumber < 14) {
+                hideNeedHackScreen();
+            } else {
+                needHackScreen(() => {
+                    ToyApp.showClubhouse('ada');
+                });
+            }
+        }
     }
 
     setSeparatorPosition(gameObject) {
@@ -1272,6 +1286,7 @@ class GameScene extends Phaser.Scene {
     restartLevel() {
         if (this.isAnimating)
             return;
+
         Sounds.play('sidetrack/sfx/start_chime');
         globalParameters.currentLevel = this.params.level;
         this.scene.restart(levelParameters[globalParameters.currentLevel]);

--- a/common/pauseToyApp.js
+++ b/common/pauseToyApp.js
@@ -25,6 +25,43 @@ function sleepScenes() {
   }
 }
 
+var NEED_HACK_MODAL = null;
+
+function needHackScreen(clickCB = null) {
+    if (NEED_HACK_MODAL) {
+        NEED_HACK_MODAL.style.display = 'block';
+        return;
+    }
+
+    NEED_HACK_MODAL = document.createElement('div');
+    NEED_HACK_MODAL.classList.add('needHack');
+
+    NEED_HACK_MODAL.innerHTML = `
+        <h1>Game Over</h1>
+
+        <p> It is not possible to continue without an associated quest. </p>
+
+        <p>
+        To play more levels of Sidetrack you should engage with Ada in the Clubhouse. Try Hack and look for
+        quests related to Sidetrack.
+        </p>
+    `;
+
+    if (clickCB) {
+        const button = document.createElement('button');
+        button.addEventListener('click', clickCB);
+        button.innerHTML = 'Click here to continue';
+        NEED_HACK_MODAL.append(button);
+    }
+
+    document.body.append(NEED_HACK_MODAL);
+}
+
+function hideNeedHackScreen() {
+    if (NEED_HACK_MODAL)
+        NEED_HACK_MODAL.style.display = 'none';
+}
+
 // Enter sleep or wake mode when visibility changes
 // i.e user minimizes toy app
 document.addEventListener('visibilitychange', () => {

--- a/common/styles.css
+++ b/common/styles.css
@@ -1,0 +1,27 @@
+.needHack {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 600px;
+    height: 400px;
+    background-color: rgba(255, 255, 255, 0.8);
+    color: black;
+    border-radius: 4px;
+    box-shadow: 0px 10px 33px -22px rgba(0,0,0,0.75);
+    text-align: center;
+    padding: 40px;
+}
+
+.needHack button {
+    margin-top: 30px;
+    display: block;
+    padding: 10px;
+    background-color: green;
+    color: white;
+    font-weight: bold;
+    margin: 0 auto;
+    border-radius: 4px;
+    border: none;
+    box-shadow: 0px 10px 33px -22px rgba(0,0,0,0.75);
+}

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -28,6 +28,7 @@
     "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
     "--env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas/",
     "--env=GTK3_MODULES=/app/clippy/lib/libclippy-module.so",
+    "--talk-name=com.hack_computer.Clubhouse",
     "--talk-name=com.hack_computer.GameStateService",
     "--talk-name=com.hack_computer.HackSoundServer",
     "--talk-name=org.gnome.Shell",

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,12 @@ if app_id == 'com.hack_computer.LightSpeed' or app_id == 'com.hack_computer.Side
     )
 endif
 
+install_data(
+    join_paths('common', 'styles.css'),
+    install_dir: 'share/toy/app',
+    rename: 'common.css'
+)
+
 data = configuration_data()
 data.set('APP_ID', app_id)
 runner = configure_file(

--- a/template/app.js
+++ b/template/app.js
@@ -1,5 +1,6 @@
 window.ToyApp = {
     isHackMode: false,
+    runningQuest: '',
 
     hideToolbox() {
         window.webkit.messageHandlers.ToyAppHideToolbox.postMessage({});
@@ -30,6 +31,10 @@ window.ToyApp = {
 
     quit(msFadeOut = 0) {
         window.webkit.messageHandlers.ToyAppQuit.postMessage(msFadeOut);
+    },
+
+    showClubhouse(characterName = 'ada') {
+        window.webkit.messageHandlers.ToyAppShowClubhouse.postMessage(characterName);
     },
 };
 

--- a/template/clubhouse.py
+++ b/template/clubhouse.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2019 Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+
+from gi.repository import Gio
+from gi.repository import GLib
+from gi.repository import GObject
+
+logger = logging.getLogger(__name__)
+
+
+class Clubhouse(GObject.Object):
+    _INTERFACE_NAME = 'com.hack_computer.Clubhouse'
+    _DBUS_PATH = '/' + _INTERFACE_NAME.replace('.', '/')
+    _proxy = None
+    _action_group = None
+
+    @classmethod
+    def get_proxy(klass):
+        if klass._proxy is None:
+            klass._proxy = Gio.DBusProxy.new_for_bus_sync(Gio.BusType.SESSION,
+                                                         0,
+                                                         None,
+                                                         klass._INTERFACE_NAME,
+                                                         klass._DBUS_PATH,
+                                                         klass._INTERFACE_NAME,
+                                                         None)
+
+        return klass._proxy
+
+
+    @classmethod
+    def get_action_group(klass):
+        if klass._action_group is None:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            klass._action_group = Gio.DBusActionGroup.get(
+                bus, klass._INTERFACE_NAME,
+                klass._DBUS_PATH)
+            klass._action_group.list_actions()
+        return klass._action_group
+
+    @classmethod
+    def show_clubhouse(klass, character_name):
+        action_group = klass.get_action_group()
+        variant = GLib.Variant('s', character_name)
+        action_group.activate_action('show-character', variant)
+
+    @classmethod
+    def property_connect(klass, prop_name, callback, *args):
+        def _props_changed_cb(_proxy, changed_properties, _invalidated, *args):
+            changed_properties_dict = changed_properties.unpack()
+            if prop_name in changed_properties_dict:
+                new_value = changed_properties_dict.get(prop_name)
+                callback(new_value, *args)
+
+        proxy = klass.get_proxy()
+
+        prop = proxy.get_cached_property(prop_name)
+        if prop is not None:
+            callback(prop.unpack())
+        return proxy.connect('g-properties-changed', _props_changed_cb, *args)


### PR DESCRIPTION
Sidetrack is playable until level 14 without quest or FtH, this patch
adds a new modal screen when the level is bigger that 14 and the hack
mode is disabled or there's no quest running.

This new modal has a button that opens the clubhouse on click.

The click on the button depends on this PR: https://github.com/endlessm/clubhouse/pull/971

https://phabricator.endlessm.com/T28810