### PR TITLE
Adapt app code to eos-hack-extension for 3.8

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -32,7 +32,8 @@
     "--talk-name=com.hack_computer.GameStateService",
     "--talk-name=com.hack_computer.HackSoundServer",
     "--talk-name=org.gnome.Shell",
-    "--talk-name=com.hack_computer.HackableAppsManager"
+    "--talk-name=com.hack_computer.HackableAppsManager",
+    "--talk-name=com.hack_computer.hack"
   ],
   "modules": [
     {


### PR DESCRIPTION
In EOS 3.8 the shell code will be moved to a shell extension and
instead of storing the hack-mode-enabled in a shell setting it's
provided by a new dbus service.

This patch tries to read the hack mode enabled from the new dbus
service and if it's not there it fallback to the old setting to
make it compatible with EOS 3.7 and earlier.

https://phabricator.endlessm.com/T29699