### PR TITLE
Sidetrack: Make it functional without app bundle

### DIFF
--- a/com.hack_computer.Sidetrack/app/common.css
+++ b/com.hack_computer.Sidetrack/app/common.css
@@ -1,0 +1,1 @@
+../../common/styles.css

--- a/com.hack_computer.Sidetrack/app/js/main.js
+++ b/com.hack_computer.Sidetrack/app/js/main.js
@@ -89,7 +89,7 @@ var game = new Phaser.Game(config);
 
 /* Quests can start a level programatically */
 game.events.on('global-property-change', (obj, property) => {
-    if (Object.is(globalParameters, obj) && property === 'startLevel') {
+    if (property === 'startLevel') {
         const startLevel = globalParameters.startLevel;
 
         if (startLevel < 0 || startLevel > globalParameters.availableLevels)

--- a/com.hack_computer.Sidetrack/app/phaser.min.js
+++ b/com.hack_computer.Sidetrack/app/phaser.min.js
@@ -1,0 +1,1 @@
+../../common/phaser-3.17.0.min.js


### PR DESCRIPTION
This patch adds some links to the needed common resources inside the app
to make it functional without the flatpak bundle so we can use this toy
app in the hack-web.

The globalParameters check is removed in main.js because the hack-web
creates a Proxy and the variable won't be the same, in any case this
change shouldn't affect the app behavior because the startLevel property
is only present in the globalParameters.

https://phabricator.endlessm.com/T29727