### PR TITLE
manifest: Fix jenkins mode

### DIFF
--- a/generate_manifest
+++ b/generate_manifest
@@ -71,6 +71,8 @@ fi
 if [ -n "$JENKINS_MODE" ]; then
   sed \
     -e "s|@APP_ID@|${APP_ID}|g" \
+    -e "s|@GIT_PATH@|${GIT_PATH}|g" \
+    -e "s|@GIT_COMMIT@|${GIT_COMMIT}|g" \
     manifest.json.in \
     > ${APP_ID}.json.in
 else


### PR DESCRIPTION
This patch just replaces the GIT_PATH and GIT_COMMIT in jenkins mode so
the .in file created with that mode is a valid json file and buils the
current repository.

https://phabricator.endlessm.com/T31064

https://github.com/endlessm/hack-toy-apps/commit/32bdd29a26b5ef8475ca26ae60b08be48e4cc55d#r43904966