### PR TITLE
manifest: update flatpak version requirement

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -24,7 +24,8 @@
     "--talk-name=com.hack_computer.HackSoundServer",
     "--talk-name=org.gnome.Shell",
     "--talk-name=com.hack_computer.HackableAppsManager",
-    "--talk-name=com.hack_computer.hack"
+    "--talk-name=com.hack_computer.hack",
+    "--require-version=1.8.2"
   ],
   "modules": [
     {


### PR DESCRIPTION
This will prevent the app from being installed on older systems through
the app store as it requires the latest Flatpak version to be present on
the system.

 * EOS3.8: flatpak version 1.6.2
 * EOS3.9: flatpak version 1.8.2