### PR TITLE
Sidetrack: Set minimum size

### DIFF
--- a/com.hack_computer.Sidetrack/data/metadata.json
+++ b/com.hack_computer.Sidetrack/data/metadata.json
@@ -1,3 +1,9 @@
 {
-    "use-load-notify": true
+    "use-load-notify": true,
+    "geometry-hints": {
+        "min-width": 1280,
+        "min-height": 749,
+        "min-aspect": 1.708,
+        "max-aspect": 1.708
+    }
 }


### PR DESCRIPTION
I've set a minimum size and aspect ratio that I've identified that it's okay with a gnome desktop with Adwaita.

https://phabricator.endlessm.com/T31084