### PR TITLE
sidetrack: Manage background outside of game

### DIFF
--- a/com.hack_computer.Sidetrack/app/index.html
+++ b/com.hack_computer.Sidetrack/app/index.html
@@ -38,7 +38,7 @@
         }
 
         .bgImage {
-            background-image: url("assets/images/pauseScreen.jpg");
+            background-image: url("assets/images/pauseScreen.jpg") !important;
         }
     </style>
     <link type="text/css" rel="stylesheet" href="common.css">

--- a/com.hack_computer.Sidetrack/app/js/main.js
+++ b/com.hack_computer.Sidetrack/app/js/main.js
@@ -43,7 +43,7 @@ const loadingScene = new LoadingScene('Loading');
 var config = {
     title: 'Sidetrack',
     type: Phaser.AUTO,
-    backgroundColor: 'ffffff',
+    transparent: true,
     width: 1920,
     height: 1080,
     scale: {

--- a/com.hack_computer.Sidetrack/app/js/scenes/gameScene.js
+++ b/com.hack_computer.Sidetrack/app/js/scenes/gameScene.js
@@ -143,27 +143,23 @@ class GameScene extends Phaser.Scene {
             this.robotBDirection =
                 GameScene.getRobotDirection(this.params.robotBDirection, ROBOTB);
         }
-
-        this.cameras.main.setBackgroundColor('#131430');
     }
 
     create() {
         Sounds.stop('sidetrack/bg/lobby_loop');
         // create bg sprite and add background audio
-        let bg;
+        const bgTag = document.querySelector('.bg');
+        bgTag.style.backgroundSize = '100% 100%';
         if (globalParameters.currentLevel >= 40) {
             Sounds.playLoop('sidetrack/bg/bonus_mode');
-            bg = this.add.sprite(0, 0, 'background3'); // for final and bonus level
+            bgTag.style.backgroundImage = 'url("assets/images/background3.jpg")';
         } else if (globalParameters.currentLevel >= 14) {
             Sounds.playLoop('sidetrack/bg/auto_mode');
-            bg = this.add.sprite(0, 0, 'background2'); // auto mode levels
+            bgTag.style.backgroundImage = 'url("assets/images/background2.jpg")';
         } else {
             Sounds.playLoop('sidetrack/bg/manual_mode');
-            bg = this.add.sprite(0, 0, 'background1'); // manual and default
+            bgTag.style.backgroundImage = 'url("assets/images/background1.jpg")';
         }
-
-        // change the origin to the top-left corner
-        bg.setOrigin(0, 0);
 
         this.displayLevelUI();
 


### PR DESCRIPTION
This patch sets the background image to the body tag and makes it to
take the whole space so there's no black bars.

The game background is now transparent and we just update the body html
tag background using plain javascript.

https://phabricator.endlessm.com/T31125