### PR TITLE
Add Education category to metainfo

### DIFF
--- a/com.hack_computer.Sidetrack/data/metainfo.xml
+++ b/com.hack_computer.Sidetrack/data/metainfo.xml
@@ -5,6 +5,8 @@
   <project_license>GPL-2.0</project_license>
   <categories>
     <category>Game</category>
+    <category>Education</category>
+    <category>LearnToCode</category>
   </categories>
   <name>Sidetrack</name>
   <summary>Escape the maze of pits and robots!</summary>
@@ -31,10 +33,6 @@
   </metadata>
 
   <url type="homepage">https://hack-computer.com</url>
-
-  <categories>
-    <category>LearnToCode</category>
-  </categories>
 
   <releases>
     <release date="2019-12-12" version="1.1"/>


### PR DESCRIPTION
Combine in the second definition of the `<categories>` so the original categories don’t get overwritten.

The `Education` category is what’s defined in the [freedesktop menu specification](https://specifications.freedesktop.org/menu-spec/latest/apas02.html); the `LearnToCode` category was custom and not supported outside Endless’ fork of gnome-software. The changes in gnome-software to support it have now been dropped.

https://phabricator.endlessm.com/T33044