### PR TITLE
template: Depends on webkit2gtk-4.0 to against GNOME Sdk 42

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -10,7 +10,7 @@
   },
   "branch": "@BRANCH@",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "@APP_ID@",
   "finish-args": [

--- a/template/app.py
+++ b/template/app.py
@@ -24,7 +24,7 @@ import os
 import sys
 gi.require_version('Gdk', '3.0')  # nopep8
 gi.require_version('Gtk', '3.0')  # nopep8
-gi.require_version('WebKit2', '4.1')  # nopep8
+gi.require_version('WebKit2', '4.0')  # nopep8
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib


### PR DESCRIPTION
Follow the commit ("Downgrade the runtime to GNOME 42") of flatpak app com.hack_computer.Clubhouse [1] for compatibilty.

[1]: https://github.com/flathub/com.hack_computer.Clubhouse

https://phabricator.endlessm.com/T34137